### PR TITLE
Implement Zustand game store

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,36 +1,77 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Button } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { useGameStore } from './store/useGameStore';
 
 function HomeScreen() {
+  const { vitals, time } = useGameStore();
+  const format = (n: number) => n.toString().padStart(2, '0');
   return (
     <View style={styles.container}>
-      <Text>Home Screen</Text>
+      <Text>Energy: {vitals.energy}</Text>
+      <Text>Hunger: {vitals.hunger}</Text>
+      <Text>Thirst: {vitals.thirst}</Text>
+      <Text>Health: {vitals.health}</Text>
+      <Text>
+        Day {time.day} {format(time.hour)}:{format(time.minute)}
+      </Text>
     </View>
   );
 }
 
 function ActionsScreen() {
+  const { vitals, inventory, setVitals, setInventory } = useGameStore();
+
+  const handleEat = () => {
+    if (inventory.food > 0) {
+      setInventory({ food: inventory.food - 1 });
+      setVitals({ hunger: Math.max(0, vitals.hunger - 10) });
+    }
+  };
+
+  const handleDrink = () => {
+    if (inventory.water > 0) {
+      setInventory({ water: inventory.water - 1 });
+      setVitals({ thirst: Math.max(0, vitals.thirst - 10) });
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Text>Actions Screen</Text>
+      <Button title="Eat Food" onPress={handleEat} />
+      <Button title="Drink Water" onPress={handleDrink} />
     </View>
   );
 }
 
 function InventoryScreen() {
+  const { inventory } = useGameStore();
   return (
     <View style={styles.container}>
-      <Text>Inventory Screen</Text>
+      <Text>Wires: {inventory.wires}</Text>
+      <Text>Crystals: {inventory.crystals}</Text>
+      <Text>Minerals: {inventory.minerals}</Text>
+      <Text>Metal: {inventory.metal}</Text>
+      <Text>Food: {inventory.food}</Text>
+      <Text>Water: {inventory.water}</Text>
     </View>
   );
 }
 
 function SleepScreen() {
+  const { setVitals, advanceTime } = useGameStore();
+
+  const handleSleep = () => {
+    setVitals({ energy: 100 });
+    advanceTime(8 * 60);
+  };
+
   return (
     <View style={styles.container}>
       <Text>Sleep Screen</Text>
+      <Button title="Sleep 8 Hours" onPress={handleSleep} />
     </View>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-safe-area-context": "^5.5.1",
-        "react-native-screens": "^4.11.1"
+        "react-native-screens": "^4.11.1",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -7745,6 +7746,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.5.1",
-    "react-native-screens": "^4.11.1"
+    "react-native-screens": "^4.11.1",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/store/useGameStore.ts
+++ b/store/useGameStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export interface Vitals {
+  energy: number;
+  hunger: number;
+  thirst: number;
+  health: number;
+}
+
+export interface Inventory {
+  wires: number;
+  crystals: number;
+  minerals: number;
+  metal: number;
+  food: number;
+  water: number;
+}
+
+export interface GameTime {
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+interface GameState {
+  vitals: Vitals;
+  inventory: Inventory;
+  time: GameTime;
+  setVitals: (partial: Partial<Vitals>) => void;
+  setInventory: (partial: Partial<Inventory>) => void;
+  advanceTime: (minutes: number) => void;
+}
+
+export const useGameStore = create<GameState>((set) => ({
+  vitals: { energy: 100, hunger: 0, thirst: 0, health: 100 },
+  inventory: { wires: 0, crystals: 0, minerals: 0, metal: 0, food: 0, water: 0 },
+  time: { day: 1, hour: 8, minute: 0 },
+  setVitals: (partial) =>
+    set((state) => ({ vitals: { ...state.vitals, ...partial } })),
+  setInventory: (partial) =>
+    set((state) => ({ inventory: { ...state.inventory, ...partial } })),
+  advanceTime: (minutes) =>
+    set((state) => {
+      let minute = state.time.minute + minutes;
+      let hour = state.time.hour + Math.floor(minute / 60);
+      minute = minute % 60;
+      let day = state.time.day + Math.floor(hour / 24);
+      hour = hour % 24;
+      return { time: { day, hour, minute } };
+    }),
+}));


### PR DESCRIPTION
## Summary
- add zustand dependency
- create `useGameStore` to hold vitals, inventory and time
- display vitals and time on Home screen
- allow eating and drinking from Actions screen
- show resources in Inventory screen
- allow sleeping to recover energy and advance time

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686ec2bfc90083289cc0cc9086634a37