### PR TITLE
Implement energy-based actions with progress bar

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.json' {
+  const value: any;
+  export default value;
+}

--- a/src/data/actions.json
+++ b/src/data/actions.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "salvage",
+    "name": "Salvage",
+    "energyCost": 15,
+    "duration": 5,
+    "yield": { "metal": 2, "wires": 1 }
+  },
+  {
+    "id": "harvest",
+    "name": "Harvest",
+    "energyCost": 10,
+    "duration": 4,
+    "yield": { "food": 1, "water": 1 }
+  }
+]


### PR DESCRIPTION
## Summary
- add `actions.json` defining cost, duration and yield for tasks
- display actions to perform in `ActionsScreen`
- animate a progress bar while a task runs
- update inventory and energy after completion
- allow JSON imports by adding `declarations.d.ts`

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686ec7cfc8408328833e9407da6aa76d